### PR TITLE
Allow configuration of Azure sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,31 @@ The following table lists the configurable parameters of the Instana chart and t
 | `instana.agent.endpoint.host` | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`               |
 | `instana.agent.endpoint.port` | Instana agent backend endpoint port                                     | `443`                                     |
 | `podAnnotations`              | Additional annotations to apply to the pod.                             | `{}`                                      |
+| `instana.azure.enabled`        | Whether the Azure sensor should be enabled or not                      | `false`                                   |
+| `instana.azure.subscription_id`| Azure Subscription ID                                                  | `Nil`                                     |
+| `instana.azure.tenant_id`      | Azure Tenant ID                                                        | `Nil`                                     |
+| `instana.azure.sp_id`          | Azure Service Principal ID                                             | `Nil`                                     |
+| `instana.azure.sp_secret`      | Azure Service Principal secret                                         | `Nil`                                     |
 
 ### Agent
 
 There is a [config map](templates/configmap.yaml) which you can edit to configure agent. This configuration will be used for all instana agents on all nodes.
+
+### Usage with Microsoft Azure
+
+To enable the Azure sensors, you need to add your service principal credentials to the command provided above.
+
+To install the chart with the release name `instana-agent` and Azure Service Principal credentials, run:
+
+```bash
+$ helm install . --name instana-agent --namespace instana-agent \
+--set instana.agent.key=INSTANA_AGENT_KEY \
+--set instana.agent.endpoint.host=HOST \
+--set instana.agent.endpoint.port=PORT \
+--set instana.zone=K8s-cluster \
+--set instana.azure.enabled=true \
+--set instana.azure.subscription_id=your-subscription-id \
+--set instana.azure.tenant_id=your-tenant-id \
+--set instana.azure.sp_id=your-service-principal-id \
+--set instana.azure.sp_secret=your-service-principal-secret
+```

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -38,6 +38,28 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.instana.agent.name }}-secret
                   key: key
+{{- if .Values.instana.azure.enabled }}
+            - name: INSTANA_AZURE_SUBSCRIPTION
+              valueFrom:
+                secretKeyRef:
+                    name: {{ .Values.instana.agent.name }}-azure-secret
+                    key: subscription_id
+            - name: INSTANA_AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                    name: {{ .Values.instana.agent.name }}-azure-secret
+                    key: tenant_id
+            - name: INSTANA_AZURE_SPID
+              valueFrom:
+                secretKeyRef:
+                    name: {{ .Values.instana.agent.name }}-azure-secret
+                    key: sp_id
+            - name: INSTANA_AZURE_SPSECRET
+              valueFrom:
+                secretKeyRef:
+                    name: {{ .Values.instana.agent.name }}-azure-secret
+                    key: sp_secret
+{{- end }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -5,3 +5,16 @@ metadata:
 type: Opaque
 data:
   key: {{ .Values.instana.agent.key | b64enc | quote }}
+{{- if .Values.instana.azure.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.instana.agent.name }}-azure-secret
+type: Opaque
+data:
+  subscription_id: {{ .Values.instana.azure.subscription_id | b64enc | quote }}
+  tenant_id: {{ .Values.instana.azure.tenant_id | b64enc | quote }}
+  sp_id: {{ .Values.instana.azure.sp_id | b64enc | quote }}
+  sp_secret: {{ .Values.instana.azure.sp_secret | b64enc | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,12 @@ instana:
     endpoint:
       host: saas-us-west-2.instana.io
       port: 443
+  azure:
+    enabled: false
+    # subscription_id: your subscription id
+    # tenant_id: your tenant id
+    # sp_id: your service principal id
+    # sp_secret: your service principal secret
 
 ## Annotations to be added to pods
 podAnnotations: {}


### PR DESCRIPTION
The Instana Azure platform sensors are activated through
environment variables (`INSTANA_AZURE_*`).

This changeset allows the configuration of all required
credentials and stores them as secret.