### PR TITLE
Create tiller-service-account.yaml

### DIFF
--- a/tiller-service-account.yaml
+++ b/tiller-service-account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
I added the `tiller-service-account.yaml` as mentioned in the README so other people don´t have to copy/paste the yaml content and can start deploying the RBAC role right away