### PR TITLE
New k8s permissions

### DIFF
--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -20,6 +20,11 @@ rules:
     - "replicasets"
     - "ingresses"
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - "deployments"
+    - "replicasets"
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
     - "namespaces"

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -40,5 +40,5 @@ rules:
 - apiGroups: [""]
   resources:
     - "endpoints"
-  verbs: ["create", "update"]
+  verbs: ["create", "update", "patch"]
 {{- end -}}


### PR DESCRIPTION
### What

1. Add `get`, `list`, `watch` permissions for `deployments` and `replicasets` to the `apps` apigroup
2. Add `patch` permission for `endpoints`

### Why
https://www.pivotaltracker.com/n/projects/2203710/stories/163224944

Since the `fabric8` kubernetes-client has been updated to v4.1.1, and [the `Extensions` API Group has been deprecated](https://github.com/fabric8io/kubernetes-client#major-changes-in-kubernetes-client-400), when we did the fabric8 kubernetes-client upgrade, we had to introduce the `BackwardsCompatibleExtensionsAPIGroupClient` that will continue to use the `Extensions` API Group (instead of the new `Apps` API Group).

This change introduces the new `apps` permissions for `deployments` and `replicaset` in anticipation of when we do remove the `BackwardsCompatibleExtensionsAPIGroupClient` class, things will continue to still work.

### Testing

I tested this 2 ways locally:
- With _no_ modifications to the current sensor code:
  - Reinstalled the helm chart with these changes
  - Watch `kubectl` logs for `instana-agent` and ensure there are no permissions errors
- With modifications to the current sensor code:
  - Remove all usages of the `BackwardsCompatibleExtensionsAPIGroupClient` class in `InstanaKubernetesClient`.
  - Call `resource.patch()` in `ClusterIdService#replaceEndpointsResource` instead of having to lock the resource and then calling `replace`
  - Rebuilt the kubernetes sensor docker image
  - Reinstalled the helm chart with these changes
  - Watch `kubectl` logs for `instana-agent` and ensure there are no permissions errors