### PR TITLE
Expose the 'INSTANA_AGENT_HTTP_LISTEN' variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Optionally, if your infrastructure uses a proxy, you should ensure that you set 
 Optionally, if your infrastructure has multiple networks defined, might need to allow the agent listening on all
 addresses (typically with value set to '*'):
 
-* instana.agent.http.listen
+* instana.agent.httpListen
 
 Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
 
@@ -84,7 +84,7 @@ $ helm install . --name instana-agent --namespace instana-agent \
 --set instana.agent.proxyUser=INSTANA_AGENT_PROXY_USER \
 --set instana.agent.proxyPassword=INSTANA_AGENT_PROXY_PASSWORD \
 --set instana.agent.proxyUseDNS=INSTANA_AGENT_PROXY_USE_DNS \
---set instana.agent.http.listen=INSTANA_AGENT_HTTP_LISTEN
+--set instana.agent.httpListen=INSTANA_AGENT_HTTP_LISTEN
 ```
 
 To install the chart with the release name `instana-agent` after editing the **values.yaml** file, run:
@@ -125,7 +125,7 @@ The following table lists the configurable parameters of the Instana chart and t
 | `instana.agent.proxyUser`          | Username of the proxy auth                                              | `nil`                                     |
 | `instana.agent.proxyPassword`      | Password of the proxy auth                                              | `nil`                                     |
 | `instana.agent.proxyUseDNS`        | Boolean if proxy also does DNS                                          | `nil`                                     |
-| `instana.agent.http.listen`        | List of addresses to listen on, or "*" for all interfaces               | `nil`                                     |
+| `instana.agent.httpListen`         | List of addresses to listen on, or "*" for all interfaces               | `nil`                                     |
 | `computeResources.requests.memory` | Container memory requests in MiB                                        | `512`                                     |
 | `computeResources.requests.cpu`    | Container cpu requests in cpu cores                                     | `0.5`                                     |
 | `computeResources.limits.memory`   | Container memory limits in MiB                                          | `512`                                     |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Optionally, if your infrastructure uses a proxy, you should ensure that you set 
 * instana.agent.proxyPassword
 * instana.agent.proxyUseDNS
 
+Optionally, if your infrastructure has multiple networks defined, might need to allow the agent listening on all
+addresses (typically with value set to '*'):
+
+* instana.agent.http.listen
+
 Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
 
 To install the chart with the release name `instana-agent` and set the values on the command line run:
@@ -78,7 +83,8 @@ $ helm install . --name instana-agent --namespace instana-agent \
 --set instana.agent.proxyProtocol=INSTANA_AGENT_PROXY_PROTOCOL \
 --set instana.agent.proxyUser=INSTANA_AGENT_PROXY_USER \
 --set instana.agent.proxyPassword=INSTANA_AGENT_PROXY_PASSWORD \
---set instana.agent.proxyUseDNS=INSTANA_AGENT_PROXY_USE_DNS
+--set instana.agent.proxyUseDNS=INSTANA_AGENT_PROXY_USE_DNS \
+--set instana.agent.http.listen=INSTANA_AGENT_HTTP_LISTEN
 ```
 
 To install the chart with the release name `instana-agent` after editing the **values.yaml** file, run:
@@ -119,6 +125,7 @@ The following table lists the configurable parameters of the Instana chart and t
 | `instana.agent.proxyUser`          | Username of the proxy auth                                              | `nil`                                     |
 | `instana.agent.proxyPassword`      | Password of the proxy auth                                              | `nil`                                     |
 | `instana.agent.proxyUseDNS`        | Boolean if proxy also does DNS                                          | `nil`                                     |
+| `instana.agent.http.listen`        | List of addresses to listen on, or "*" for all interfaces               | `nil`                                     |
 | `computeResources.requests.memory` | Container memory requests in MiB                                        | `512`                                     |
 | `computeResources.requests.cpu`    | Container cpu requests in cpu cores                                     | `0.5`                                     |
 | `computeResources.limits.memory`   | Container memory limits in MiB                                          | `512`                                     |

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -62,9 +62,9 @@ spec:
             - name: INSTANA_AGENT_PROXY_USE_DNS
               value: {{ .Values.instana.agent.proxyUseDNS | quote }}
             {{- end }}
-            {{- if .Values.instana.agent.http.listen }}
+            {{- if .Values.instana.agent.httpListen }}
             - name: INSTANA_AGENT_HTTP_LISTEN
-              value: {{ .Values.instana.agent.http.listen | quote }}
+              value: {{ .Values.instana.agent.httpListen | quote }}
             {{- end }}
             - name: JAVA_OPTS
               value: "-Xmx{{ div .Values.computeResources.requests.memory 3 }}M -XX:+ExitOnOutOfMemoryError"

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -62,6 +62,10 @@ spec:
             - name: INSTANA_AGENT_PROXY_USE_DNS
               value: {{ .Values.instana.agent.proxyUseDNS | quote }}
             {{- end }}
+            {{- if .Values.instana.agent.http.listen }}
+            - name: INSTANA_AGENT_HTTP_LISTEN
+              value: {{ .Values.instana.agent.http.listen | quote }}
+            {{- end }}
             - name: JAVA_OPTS
               value: "-Xmx{{ div .Values.computeResources.requests.memory 3 }}M -XX:+ExitOnOutOfMemoryError"
           securityContext:


### PR DESCRIPTION
Makes it possible to let the Instana Agent listen on all network
interfaces. By default will only listen on eth0 / any Docker bridge
network.
In general value of "*" should be provided so the agent will listen on
all networking interfaces