### PR TITLE
Use agent pod uid as leader election id to avoid hostname inconsistencies between leader elector and agent

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -68,6 +68,10 @@ spec:
             {{- end }}
             - name: JAVA_OPTS
               value: "-Xmx{{ div .Values.computeResources.requests.memory 3 }}M -XX:+ExitOnOutOfMemoryError"
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             privileged: true
           volumeMounts:
@@ -99,7 +103,12 @@ spec:
               cpu: {{ .Values.computeResources.limits.cpu }}
         - name: {{ .Values.instana.agent.name }}-leader-elector
           image: gcr.io/google-containers/leader-elector:0.5
-          args: ["--election=instana", "--http=0.0.0.0:{{ .Values.instana.leaderElectorPort }}"]
+          env:
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          args: ["--election=instana", "--http=0.0.0.0:{{ .Values.instana.leaderElectorPort }}", "--id=$(INSTANA_AGENT_POD_NAME)"]
           resources:
             requests:
               cpu: 0.1


### PR DESCRIPTION
## Why

See https://github.com/instana/sensors/pull/1502

## What

Use the K8s downwards api to pass in the pod name to the sensor and leader elector via an environment variable.