### PR TITLE
fixed missing tolerations in pod spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following table lists the configurable parameters of the Instana chart and t
 | `instana.agent.endpoint.host`      | Instana agent backend endpoint host                                     | `saas-us-west-2.instana.io`               |
 | `instana.agent.endpoint.port`      | Instana agent backend endpoint port                                     | `443`                                     |
 | `podAnnotations`                   | Additional annotations to apply to the pod                              | `{}`                                      |
+| `tolerations`                      | Tolerations for pod assignment                                          | `[]`                                      |
 | `instana.agent.proxyHost`          | Hostname/address of a proxy                                             | `nil`                                     |
 | `instana.agent.proxyPort`          | Port of a proxy                                                         | `nil`                                     |
 | `instana.agent.proxyProtocol`      | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                     |

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -119,6 +119,10 @@ spec:
               port: 42699
             initialDelaySeconds: 75
             periodSeconds: 5
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8}}
+{{- end }}
       volumes:
         - name: dev
           hostPath:

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,10 @@ instana:
 ## Annotations to be added to pods
 podAnnotations: {}
 
+## Tolerations for pod assignment
+### Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 computeResources:
   requests:
     memory: 512 # memory requests in MiB


### PR DESCRIPTION
This PR adds tolerations to the pod spec, this allows the user to schedule instana-agents on to the master nodes, with the correct values (default []).